### PR TITLE
edit middleware

### DIFF
--- a/middleware/authenticateToken.js
+++ b/middleware/authenticateToken.js
@@ -18,21 +18,21 @@ const authToken = async (req, res, next) => {
         },
       ],
     });
-  }
-
-  // Authenticate token
-  try {
-    const user = await jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-    req.user = user.email;
-    next();
-  } catch (error) {
-    res.status(403).json({
-      errors: [
-        {
-          msg: "Invalid token",
-        },
-      ],
-    });
+  } else {
+    // Authenticate token
+    try {
+      const user = await jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+      req.user = user.email;
+      next();
+    } catch (error) {
+      res.status(403).json({
+        errors: [
+          {
+            msg: "Invalid token",
+          },
+        ],
+      });
+    }
   }
 };
 


### PR DESCRIPTION
If I send request without access-token, then server crash with "Cannot set headers after they are sent to the client" error.
I think that's because the application set header twice when we send request without access-token.
So, it can be solved by appliying if-else statement